### PR TITLE
Add Context, Data, and Errors to callback Option

### DIFF
--- a/js/forms/motif.ajax-submission.js
+++ b/js/forms/motif.ajax-submission.js
@@ -166,7 +166,7 @@
          * runs callback (if there).
          * @method afterSubmit
          */
-        "afterSubmit": function () {
+        "afterSubmit": function ( data, error ) {
             var message = this.options.feedbackMessage ? this.buildMessage() : false;
 
             // If there was no error...

--- a/js/forms/motif.ajax-submission.js
+++ b/js/forms/motif.ajax-submission.js
@@ -156,7 +156,7 @@
             }
 
             // ...then call the after-submission method
-            this.afterSubmit();
+            this.afterSubmit( data, error );
 
             return data;
         },
@@ -183,7 +183,7 @@
             if ( typeof this.options.callback === "function" ) {
 
                 // ...call it, passing on this form as context
-                this.options.callback();
+                this.options.callback( this.$elem, data, error );
             }
         },
 


### PR DESCRIPTION
### Description of Problem
No context, data, or errors are provided to users when using a custom callback option, making it hard to do anything useful considering there is no way to differentiate between success and failure. The callback gets called in either scenario but provides no indication of what the result was.

### Description of Work
- User option "callback" now provides form context, ajax submission data, and any relevant errors (if they exist).