### PR TITLE
Adding `grunt-cli` as project dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   "gitHead": "cce044bb9b91bffe6cddd736bc925a22b58fbcd8",
   "dependencies": {
     "grunt": "~0.4.x",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-less": "~1.0.x",
-    "grunt-webfont": "~0.4.x",
     "grunt-contrib-uglify": "~0.9.x",
-    "grunt-contrib-watch": "~0.6.x"
+    "grunt-contrib-watch": "~0.6.x",
+    "grunt-webfont": "~0.4.x"
   }
 }


### PR DESCRIPTION
Addresses issue #6.