### PR TITLE
Bugfix - Herald is over-splicing events

### DIFF
--- a/js/scroll/motif.herald.js
+++ b/js/scroll/motif.herald.js
@@ -1,5 +1,5 @@
 /*!
- * Motif Herald v0.3.4
+ * Motif Herald v0.3.5
  * Fire off events depending on scroll position.
  * http://getmotif.com
  *
@@ -387,7 +387,7 @@
       this.isSplicing = true;
 
       $.each(this.spliceQueue, $.proxy(function eachSplice(i, v) {
-        this.options.events.splice(v, 1);
+        this.options.events[v].suspended = true;
       }, this));
 
       this.spliceQueue = [];


### PR DESCRIPTION
`v0.3.5`:

Herald used to splice non-repeating events form the events array so that it can process less and less as it moves along. There is an issue where, in certain situations and at certain speeds, that rudimentary splicing process accidently splices too many events, causing some events to never get a chance to fire.

The current solution is to take advantage of the `suspended` flag on events and suspend non-repeating items rather than splicing. It's technically less performant, but okay for now until a larger refactoring happens.