### PR TITLE
Custom Throttle pass through ability.

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -81,7 +81,7 @@ A basic sticky sidebar. (Requires **Herald**.)
 Addition of the ability to pass how much Throttle should be applied to your listener for when to apply/remove Sticky. Default is 50ms. If you see flickers, lessen this number.
 
 ```
-$(".js-stickey-element").sidekick({
+$(".js-sticky-element").sidekick({
 	"minWidth": 768,
 	"throttle": 0
 })

--- a/js/README.md
+++ b/js/README.md
@@ -69,13 +69,23 @@ Fire off events depending on scroll position.
 
 ### Sidekick
 
-**Version:** 0.1.0
+**Version:** 0.1.1
 
 **Location:** `/scroll/motif.sidekick.js`
 
 A basic sticky sidebar. (Requires **Herald**.)
 
 *Documentation coming soon!*
+
+**June 26th, 2018**
+Addition of the ability to pass how much Throttle should be applied to your listener for when to apply/remove Sticky. Default is 50ms. If you see flickers, lessen this number.
+
+```
+$(".js-stickey-element").sidekick({
+	"minWidth": 768,
+	"throttle": 0
+})
+```
 
 ### Scroll Patrol
 

--- a/js/scroll/motif.sidekick.js
+++ b/js/scroll/motif.sidekick.js
@@ -1,5 +1,5 @@
 /*!
- * Motif Sidekick v0.1.0
+ * Motif Sidekick v0.1.1
  * A basic sticky sidebar built on Motif Herald
  * http://getmotif.com
  * 

--- a/js/scroll/motif.sidekick.js
+++ b/js/scroll/motif.sidekick.js
@@ -28,7 +28,8 @@
             "bottomOffset": null,
             "keepWidth": true,
             "minWidth": false,
-            "window": $( window )
+            "window": $( window ),
+            "throttle": 50
         },
 
         "init": function ( userOptions ) {
@@ -167,7 +168,8 @@
                 var self = this;
 
                 self.$window.plugin("herald", {
-                    "events": self.heraldEvents
+                    "events": self.heraldEvents,
+                    "throttle": self.options.throttle
                 });
             }
     };


### PR DESCRIPTION
Addition of the ability to pass how much Throttle should be applied to your listener for when to apply/remove Sticky. Default is 50ms. If you see flickers, lessen this number.