### PR TITLE
Feature - Dynamic Responsive Image Sizing

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -1,11 +1,11 @@
-import "picturefill";
-import "lazysizes";
 import ui from "./ui";
+import images from "./images";
 import forms from "./forms";
 
 class App {
   constructor() {
     ui();
+    images();
     forms();
   }
 }

--- a/js/images/index.js
+++ b/js/images/index.js
@@ -1,0 +1,15 @@
+import "picturefill";
+import "lazysizes";
+import dynamicResponsiveImages from './motif.dynamic-responsive-images';
+
+export default function () {
+  initDynamicResponsiveImages();
+}
+
+export function initDynamicResponsiveImages (startingPoint = document, IMAGE_CLASS = 'js-dynamic-image', multiple = 1) {
+  const dynamicImages = startingPoint.querySelectorAll(`.${IMAGE_CLASS}`);
+
+  if (dynamicImages.length) {
+    dynamicResponsiveImages(IMAGE_CLASS, multiple);
+  }
+}

--- a/js/images/motif.dynamic-responsive-images.js
+++ b/js/images/motif.dynamic-responsive-images.js
@@ -1,0 +1,28 @@
+import "lazysizes";
+import getAnimationFrame from './../utils/motif.animationFrame.es6.js';
+
+const LAZYLOAD_CLASS = 'lazyload';
+const animationFrame = getAnimationFrame();
+
+export default function (IMAGE_CLASS = 'js-dynamic-image', multiple = 1) {
+  bindImages(IMAGE_CLASS, multiple);
+}
+
+function bindImages (IMAGE_CLASS, multiple) {
+  document.addEventListener('lazybeforesizes', function (ev) {
+    if (ev.defaultPrevented || !ev.target.classList.contains(IMAGE_CLASS)) {
+      return;
+    }
+
+    const element = ev.target;
+    const url = `${element.getAttribute('data-original')}&w=${element.parentElement.offsetWidth * multiple}&h=${element.parentElement.offsetHeight * multiple}`
+    
+    animationFrame(() => {
+      element.setAttribute('data-src', url);
+
+      if (element.classList.contains(LAZYLOAD_CLASS)) {
+        element.setAttribute('src', url);
+      }
+    });
+  });
+}

--- a/less/mixins/_m-images.less
+++ b/less/mixins/_m-images.less
@@ -1,0 +1,20 @@
+/*
+
+Dynamic Responsive Image
+
+*/
+
+.m-dynamic-responsive-image() {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    will-change: opacity;
+    transition: opacity 0.15s linear;
+
+    &.lazyloaded {
+        opacity: 1;
+    }
+}

--- a/less/mixins/_m-images.less
+++ b/less/mixins/_m-images.less
@@ -4,7 +4,7 @@ Dynamic Responsive Image
 
 */
 
-.m-dynamic-responsive-image() {
+.m-images__dynamic-responsive-image() {
     position: absolute;
     top: 0;
     left: 0;

--- a/less/mixins/_mixins.less
+++ b/less/mixins/_mixins.less
@@ -5,4 +5,5 @@
 @import '_m-type.less';
 @import '_m-forms.less';
 @import '_m-modules.less';
+@import '_m-images.less';
 @import '_m-presentational.less';

--- a/less/modules/_media.less
+++ b/less/modules/_media.less
@@ -144,24 +144,3 @@ like it placed.
         }
     }
 }
-
-/*
-
-Dynamic Responsive Image
-
-*/
-
-.dynamic-responsive-image {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    will-change: opacity;
-    transition: opacity 0.15s linear;
-
-    &.lazyloaded {
-        opacity: 1;
-    }
-}

--- a/less/modules/_media.less
+++ b/less/modules/_media.less
@@ -144,3 +144,24 @@ like it placed.
         }
     }
 }
+
+/*
+
+Dynamic Responsive Image
+
+*/
+
+.dynamic-responsive-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    will-change: opacity;
+    transition: opacity 0.15s linear;
+
+    &.lazyloaded {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
Ported over the Dynamic Responsive Images script.

## What It's For

Some images, particularly banners, aren't based on any sort of intrinsic ratio. Rather, they usually have fluidity in one axis and maybe not the other. For example, a banner image's width scales with the viewport but its height might be capped, or set to `90vh`.

Usually, we use `object-fit: cover` to still have an `img` that can cover all that fluid area, but that can lead to a couple of issues:

1. Some browsers don't support `object-fit`, so a fallback is required
2. `object-fit: cover` is very broad and blunt and leaves little room for the needs of each image's contents. It can look great for one image but the next image might result in someone's face being shoved off-screen

Dynamic Responsive Images tries to solve these by removing the need for `object-fit: cover` but still giving us the desired effect. It does this by leveraging IMGIX to return an image that fits exactly in the allotted space.

## How It Works

Our script hooks into `lazySizes`'s `lazybeforesizes` event. It measures the dimensions of the parent element to determine what is the exact image size that will fit in the area. It is then that it takes what is provided in the `data-original` attribute (presumably an IMGIX URL already containing parameters such as `fit`, `crop`, `q`, but _not_ `w` or `h`) and tacks on the newfound width and height to return the perfect image for the spot.

Some corresponding Less (`.m-images__dynamic-responsive-image();`) assumes that, because of the nature of these requirements, this image will be positioned absolutely, and will fade in once loaded.