### PR TITLE
Bugfix - Reveal and No Button

### DIFF
--- a/less/core/interactive/button.less
+++ b/less/core/interactive/button.less
@@ -98,6 +98,19 @@ Button Variations
 .button__secondary {}
  */
 
+.button__no-button {
+    background: transparent;
+    color: inherit;
+    border: 0;
+
+    &:hover,
+    &:focus,
+    &.is-current {
+        background: transparent;
+        color: inherit;
+    }
+}
+
 /*
 
 ````tiny-button

--- a/less/core/scripts/reveal.less
+++ b/less/core/scripts/reveal.less
@@ -22,7 +22,7 @@ Add the `.is-revealed` class to show it.
 
 .reveal__target {
 
-    .js {
+    .js & {
         &:extend(.presentational__is-hidden);
         
         &.is-revealed {


### PR DESCRIPTION
`reveal__target` is not working due to missing `&`. Need to add a class for buttons to remove default button styles.